### PR TITLE
Add MCP integration pipeline and agent scaffold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/powershell:latest
+
+# Install required packages
+RUN apt-get update && apt-get install -y curl jq gnupg && rm -rf /var/lib/apt/lists/*
+
+# Install Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Install Google Cloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && apt-get update && apt-get install -y google-cloud-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . /workspace
+
+CMD ["pwsh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# mcp
+# MCP Integration Example
+
+This repository demonstrates how Azure MCP can orchestrate tasks across Microsoft Graph/Intune, Chef Automate and GCP Logging. The sample includes a CI pipeline, scripts and a minimal LangChain agent.
+
+## Pipeline
+
+The `mcp_integration_pipeline.yaml` file contains an Azure DevOps pipeline that executes four steps:
+
+1. **Query Intune** – Retrieves non-compliant devices using Microsoft Graph.
+2. **Query Chef** – Downloads Chef node states.
+3. **Trigger Chef Remediation** – Starts a Chef run if the last run exceeds 24 hours.
+4. **Fetch GCP Logs** – Reads recent error logs from Cloud Logging.
+
+Required variables:
+
+- `GRAPH_TOKEN` – OAuth token for Microsoft Graph.
+- `CHEF_API_TOKEN` – API token for Chef Automate.
+- `GOOGLE_APPLICATION_CREDENTIALS` – GCP service account JSON.
+
+## LangChain Agent
+
+A basic agent implementation in `agent/langchain_skill_agent.py` wires these tasks together so you can issue natural language prompts.
+
+Run it with:
+
+```bash
+pip install -r requirements.txt
+python agent/langchain_skill_agent.py
+```
+
+The agent expects the same environment variables used in the pipeline
+(`GRAPH_TOKEN`, `CHEF_API_TOKEN` and `GOOGLE_APPLICATION_CREDENTIALS`) to be
+available so the scripts can authenticate with each service.
+
+## Docker
+
+A `Dockerfile` is provided for local development. It installs PowerShell, Azure CLI and Google Cloud CLI so you can run the scripts locally.
+
+Build the image:
+
+```bash
+docker build -t mcp-integration .
+```
+
+Then start an interactive shell:
+
+```bash
+docker run -it mcp-integration
+```

--- a/agent/langchain_skill_agent.py
+++ b/agent/langchain_skill_agent.py
@@ -1,0 +1,53 @@
+"""Simple LangChain agent integrating Intune, Chef and GCP logs."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from langchain.agents import Tool, initialize_agent
+from langchain.llms import OpenAI
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _run(cmd: list[str]) -> None:
+    """Execute a command and raise if it fails."""
+    subprocess.check_call(cmd)
+
+
+def check_device_compliance() -> str:
+    """Call the Intune PowerShell script."""
+    _run(["pwsh", str(SCRIPT_DIR / "query-intune.ps1")])
+    return "Intune compliance results exported"
+
+
+def query_chef_nodes() -> str:
+    _run(["bash", str(SCRIPT_DIR / "query-chef.sh")])
+    return "Chef node data retrieved"
+
+
+def trigger_chef_remediation() -> str:
+    _run(["bash", str(SCRIPT_DIR / "trigger-chef-run.sh")])
+    return "Chef remediation triggered"
+
+
+def fetch_error_logs() -> str:
+    _run(["bash", str(SCRIPT_DIR / "fetch-gcp-logs.sh")])
+    return "Fetched GCP logs"
+
+
+def build_agent() -> None:
+    llm = OpenAI(temperature=0)
+    tools = [
+        Tool(name="check_device_compliance", func=lambda _: check_device_compliance(), description="Check Intune compliance"),
+        Tool(name="trigger_chef_remediation", func=lambda _: trigger_chef_remediation(), description="Run Chef remediation"),
+        Tool(name="fetch_error_logs", func=lambda _: fetch_error_logs(), description="Fetch logs from GCP"),
+        Tool(name="query_chef_nodes", func=lambda _: query_chef_nodes(), description="Query Chef nodes"),
+    ]
+    agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
+    agent.run("List non-compliant devices and remediate via Chef, then fetch GCP logs")
+
+
+if __name__ == "__main__":
+    build_agent()

--- a/mcp_integration_pipeline.yaml
+++ b/mcp_integration_pipeline.yaml
@@ -1,0 +1,25 @@
+trigger: none
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  GRAPH_TOKEN: $(secretToken)
+  CHEF_API_TOKEN: $(chefToken)
+  GOOGLE_APPLICATION_CREDENTIALS: $(gcpCreds)
+
+steps:
+  - task: PowerShell@2
+    displayName: 'Query Intune for Non-Compliant Devices'
+    inputs:
+      targetType: 'filePath'
+      filePath: 'scripts/query-intune.ps1'
+
+  - script: scripts/query-chef.sh
+    displayName: 'Get Chef Node States'
+
+  - script: scripts/trigger-chef-run.sh
+    displayName: 'Trigger Chef Remediation if Last Run > 24h'
+
+  - script: scripts/fetch-gcp-logs.sh
+    displayName: 'Fetch Critical Logs from GCP Logging'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+langchain>=0.0.250
+openai

--- a/scripts/fetch-gcp-logs.sh
+++ b/scripts/fetch-gcp-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Read recent error logs from GCP Logging
+
+set -euo pipefail
+
+echo "$GOOGLE_APPLICATION_CREDENTIALS" > creds.json
+
+gcloud auth activate-service-account --key-file=creds.json
+
+gcloud logging read 'severity>=ERROR' --limit=5

--- a/scripts/query-chef.sh
+++ b/scripts/query-chef.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Fetch Chef Automate node states
+
+set -euo pipefail
+
+curl -sSL -X GET \
+  https://chef.example.com/apis/infra/nodes \
+  -H "api-token: $CHEF_API_TOKEN" \
+  -o chef_nodes.json
+
+echo "Chef node data saved to chef_nodes.json"

--- a/scripts/query-intune.ps1
+++ b/scripts/query-intune.ps1
@@ -1,0 +1,7 @@
+# Query Intune for non-compliant devices using Microsoft Graph
+param()
+
+Install-Module Microsoft.Graph.Intune -Force -Scope CurrentUser
+Connect-MSGraph -AccessToken $env:GRAPH_TOKEN
+$devices = Get-IntuneManagedDevice | Where-Object { $_.ComplianceState -eq 'noncompliant' }
+$devices | Export-Csv -Path intune_noncompliant.csv -NoTypeInformation

--- a/scripts/trigger-chef-run.sh
+++ b/scripts/trigger-chef-run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Trigger Chef run for nodes that haven't checked in within 24h
+
+set -euo pipefail
+
+if [[ ! -f chef_nodes.json ]]; then
+  echo "chef_nodes.json not found" >&2
+  exit 1
+fi
+
+NOW=$(date +%s)
+TWENTY_FOUR_HOURS=$((24 * 3600))
+
+for node in $(jq -r '.nodes[] | select(.last_run < (now - 86400)) | .id' chef_nodes.json); do
+  echo "Triggering Chef run for $node"
+  curl -sSL -X POST \
+    https://chef.example.com/apis/infra/nodes/$node/runs \
+    -H "api-token: $CHEF_API_TOKEN"
+done


### PR DESCRIPTION
## Summary
- add Azure DevOps pipeline with Intune, Chef and GCP tasks
- provide PowerShell and shell scripts for each integration step
- create a simple LangChain agent wiring the scripts together
- include Dockerfile and requirements for local dev
- update README with usage instructions
- improve agent execution with subprocess and document env vars

## Testing
- `python -m py_compile agent/langchain_skill_agent.py`
- `bash -n scripts/query-chef.sh scripts/trigger-chef-run.sh scripts/fetch-gcp-logs.sh`
